### PR TITLE
Fix for the rejected transactions.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -860,7 +860,7 @@ int CMerkleTx::GetBlocksToMaturity() const
 {
     if (!(IsCoinBase() || IsCoinStake()))
         return 0;
-    return max(0, (nCoinbaseMaturity+0) - GetDepthInMainChain());
+    return max(0, (nCoinbaseMaturity+1) - GetDepthInMainChain());
 }
 
 


### PR DESCRIPTION
When sending coins, the wallet throws an error:
error: {"code":-4,"message":"Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here."}

While debug.log shows:
ERROR: ConnectInputs() : tried to spend coinbase at depth 119
ERROR: AcceptToMemoryPool : ConnectInputs failed <hash>
CommitTransaction() : Error: Transaction not valid